### PR TITLE
fix filter for localAddress and remoteAddress

### DIFF
--- a/Invoke-DropNet.ps1
+++ b/Invoke-DropNet.ps1
@@ -215,10 +215,10 @@ function Invoke-DropNet() {
             $filteredConnections = $filteredConnections | Where-Object {$_.RemotePort -eq $RemotePort}
         }
         if(($LocalIPAddress -ne $null) -and ($LocalIPAddress -ne "")){
-            $filteredConnections = $filteredConnections | Where-Object {$_.LocalIPAddress -eq $LocalIPAddress}
+            $filteredConnections = $filteredConnections | Where-Object {$_.LocalAddress -eq $LocalIPAddress}
         }
         if(($RemoteIPAddress -ne $null) -and ($RemoteIPAddress -ne "")){
-            $filteredConnections = $filteredConnections | Where-Object {$_.RemoteIPAddress -eq $RemoteIPAddress}
+            $filteredConnections = $filteredConnections | Where-Object {$_.RemoteAddress -eq $RemoteIPAddress}
         }
         if(($State -ne $null) -and ($State -ne "")){
             $filteredConnections = $filteredConnections | Where-Object {$_.State -eq $State}


### PR DESCRIPTION
Noticed the filter is not working when specifiyng LocalIPAddress or RemoteIPAddress parameters. Issue is that wrong attribute names were used.
Can also see e.g. https://github.com/g3rzi/DropNet/blob/master/Invoke-DropNet.ps1#L241 where the correct name is used during printing.